### PR TITLE
Fix stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ DISCOVERY_UPDATE_COMMAND              | no         |
 DISCOVERY_VALIDATE_COMMAND            | no         |
 DISCOVERY_SIDECAR_ADDRESS             | yes        |
 DISCOVERY_NGINX_CONF                  | no         | /nginx/nginx.conf
+DISCOVERY_NGINX_PID                   | no         | /tmp/nginx.pid
 
 Example configuration:
 

--- a/main.go
+++ b/main.go
@@ -197,11 +197,11 @@ func main() {
 
 	// Set some defaults that are unpleasant to put in the struct definition
 	if len(config.UpdateCommand) < 1 {
-		config.UpdateCommand = `/nginx/nginx -c ` + config.NginxConf + ` -g "error_log /dev/fd/1;"`
+		config.UpdateCommand = "/bin/kill -HUP `cat /tmp/nginx.pid`"
 	}
 
 	if len(config.ValidateCommand) < 1 {
-		config.UpdateCommand = "/bin/kill -HUP `cat /tmp/nginx.pid`"
+		config.ValidateCommand = "/nginx/nginx -t -c " + config.NginxConf
 	}
 
 	rubberneck.Print(config)

--- a/main.go
+++ b/main.go
@@ -94,6 +94,8 @@ func innerUpdate(config *Config, previousServers []string) ([]string, error) {
 		return nil, fmt.Errorf("Unable to write template: %s", err)
 	}
 
+	log.Info("Reloading Nginx config...")
+
 	previousServers = servers
 
 	err = run(config.ValidateCommand)
@@ -131,7 +133,6 @@ func findPortWithSvcPortNumber(ports []service.Port, config *Config) string {
 	}
 
 	return ""
-
 }
 
 // FetchServers will connect to Sidecar, and with a timeout, fetch and
@@ -166,6 +167,14 @@ func FetchServers(config *Config) ([]string, error) {
 		portStr := findPortWithSvcPortNumber(svc.Ports, config)
 		if len(portStr) < 1 {
 			log.Warnf("Got no port match for service on hostname: %s",
+				svc.Hostname,
+			)
+			continue
+		}
+
+		if svc.Status != 0 {
+			log.Infof("Skipping service with status %d on hostname: %s",
+				svc.Status,
 				svc.Hostname,
 			)
 			continue

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ type Config struct {
 	ValidateCommand string        `envconfig:"VALIDATE_COMMAND"`
 	SidecarAddress  string        `envconfig:"SIDECAR_ADDRESS" required:"true"`
 	NginxConf       string        `envconfig:"NGINX_CONF" default:"/nginx/nginx.conf"`
+	NginxPID        string        `envconfig:"NGINX_PID" default:"/tmp/nginx.pid"`
 }
 
 type ApiServices struct {
@@ -197,7 +198,7 @@ func main() {
 
 	// Set some defaults that are unpleasant to put in the struct definition
 	if len(config.UpdateCommand) < 1 {
-		config.UpdateCommand = "/bin/kill -HUP `cat /tmp/nginx.pid`"
+		config.UpdateCommand = "/bin/kill -HUP `cat " + config.NginxPID + "`"
 	}
 
 	if len(config.ValidateCommand) < 1 {

--- a/main.go
+++ b/main.go
@@ -173,7 +173,7 @@ func FetchServers(config *Config) ([]string, error) {
 		}
 
 		if svc.Status != 0 {
-			log.Infof("Skipping service with status %d on hostname: %s",
+			log.Debugf("Skipping service with status %d on hostname: %s",
 				svc.Status,
 				svc.Hostname,
 			)

--- a/main.go
+++ b/main.go
@@ -21,7 +21,9 @@ import (
 	"gopkg.in/relistan/rubberneck.v1"
 )
 
-const LoopDelayInterval = 3 * time.Second
+const (
+	LoopDelayInterval = 3 * time.Second
+)
 
 type Config struct {
 	RefreshInterval time.Duration `envconfig:"REFRESH_INTERVAL" default:"5s"`
@@ -102,6 +104,11 @@ func innerUpdate(config *Config, previousServers []string) ([]string, error) {
 	err = run(config.ValidateCommand)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to validate nginx config! (%s)", err)
+	}
+
+	if _, err := os.Stat(config.NginxPID); os.IsNotExist(err) {
+		log.Warn("Nginx is not running yet!")
+		return servers, nil
 	}
 
 	err = run(config.UpdateCommand)

--- a/main_test.go
+++ b/main_test.go
@@ -32,6 +32,24 @@ const (
 		                "Updated": "2017-08-14T15:30:23.451172154Z",
 		                "ProxyMode": "http",
 		                "Status": 0
+		            },
+		            {
+		                "ID": "0123456789",
+		                "Name": "foo",
+		                "Image": "gonitro/foo",
+		                "Created": "2017-08-04T18:50:09Z",
+		                "Hostname": "tolkien",
+		                "Ports": [
+		                    {
+		                        "Type": "tcp",
+		                        "Port": 42042,
+		                        "ServicePort": 10101,
+		                        "IP": "10.10.10.20"
+		                    }
+		                ],
+		                "Updated": "2017-08-14T15:30:23.451172154Z",
+		                "ProxyMode": "http",
+		                "Status": 1
 		            }
 		        ]
 		    },
@@ -133,6 +151,14 @@ func Test_UpdateNginx(t *testing.T) {
 			_, err := innerUpdate(&config, previousServers)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldContainSubstring, "Unable to reload")
+		})
+
+		Convey("Does not add non-healthy servers", func() {
+			config.TemplateFile = ""
+			newServers, err := innerUpdate(&config, servers)
+
+			So(err, ShouldBeNil)
+			So(newServers, ShouldResemble, servers)
 		})
 	})
 }

--- a/main_test.go
+++ b/main_test.go
@@ -91,7 +91,10 @@ func Test_UpdateNginx(t *testing.T) {
 	Convey("UpdateNginx()", t, func() {
 		previousServers := []string{}
 
-		outFile, _ := ioutil.TempFile("", "UpdateNginx")
+		outFile, err := ioutil.TempFile("", "UpdateNginx")
+		So(err, ShouldBeNil)
+		pidFile, err := ioutil.TempFile("", "NginxPID")
+		So(err, ShouldBeNil)
 
 		config := Config{
 			TemplateFile:   "templates/nginx.conf.tmpl",
@@ -99,6 +102,7 @@ func Test_UpdateNginx(t *testing.T) {
 			FollowService:  "foo",
 			FollowPort:     10101,
 			NginxConf:      outFile.Name(),
+			NginxPID:       pidFile.Name(),
 		}
 
 		servers := []string{


### PR DESCRIPTION
@relistan Could you please have a look at these commits and let me know what you think? Here's a list of what I fixed:
- Don't add non-healthy services
- Correct Nginx update and validate commands (not sure what happened there, but it looks like some copy / paste that went wrong)
- Don't try to run the UpdateCommand if we can't find the Nginx PID file

I also saw something super-weird when I deployed the current version of nginx-raster container yesterday. Somehow, when it started, the Nginx config got screwed up and had some duplicated lines at the end, which were causing these errors:
```
2017/09/12 16:31:43 [emerg] 34#0: unexpected "{" in /nginx/nginx.conf:80
2017/09/12 16:31:43 [emerg] 34#0: unexpected "{" in /nginx/nginx.conf:80
2017/09/12 16:32:58 [emerg] 34#0: unknown directive "l" in /nginx/nginx.conf:79
2017/09/12 16:32:58 [emerg] 34#0: unknown directive "l" in /nginx/nginx.conf:79
```
I tried to reproduce it several times today, but couldn't... It feels like some weird race condition, but not sure what might cause it. Maybe `nginx-discovery` getting restarted by s6?